### PR TITLE
feat: implement SQLite event queue

### DIFF
--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -3,31 +3,188 @@
  * @see Issue #2
  */
 
-import type { Event, EventQueue } from "../types/index.ts";
+import { Database } from "bun:sqlite";
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+import type { Event, EventQueue, Logger } from "../types/index.ts";
 
-// Placeholder - will be implemented in Issue #2
+/** Row type from the events table */
+interface EventRow {
+  id: string;
+  message: string;
+  progress: string;
+  createdAt: string;
+  status: string;
+}
+
+/**
+ * SQLite-based event queue implementation
+ */
 export class SQLiteEventQueue implements EventQueue {
-  async add(_message: string): Promise<Event> {
-    throw new Error("Not implemented - Issue #2");
+  private db: Database;
+  private logger: Logger;
+
+  private constructor(db: Database, logger: Logger) {
+    this.db = db;
+    this.logger = logger;
   }
 
+  /**
+   * Creates a new SQLiteEventQueue instance
+   * @param dbPath - Path to the SQLite database file (default: ~/.otterassist/events.db)
+   * @param logger - Logger instance for debug output
+   */
+  static async create(
+    dbPath = `${homedir()}/.otterassist/events.db`,
+    logger: Logger,
+  ): Promise<SQLiteEventQueue> {
+    // Ensure directory exists
+    await mkdir(dirname(dbPath), { recursive: true });
+
+    const db = new Database(dbPath);
+
+    // Create events table if it doesn't exist
+    db.run(`
+			CREATE TABLE IF NOT EXISTS events (
+				id TEXT PRIMARY KEY,
+				message TEXT NOT NULL,
+				progress TEXT DEFAULT '',
+				createdAt TEXT NOT NULL,
+				status TEXT NOT NULL CHECK(status IN ('pending', 'completed'))
+			)
+		`);
+
+    // Create index on status for faster pending queries
+    db.run(`
+			CREATE INDEX IF NOT EXISTS idx_events_status ON events(status)
+		`);
+
+    logger.debug(`Event queue initialized at ${dbPath}`);
+
+    return new SQLiteEventQueue(db, logger);
+  }
+
+  /**
+   * Adds a new event to the queue
+   */
+  async add(message: string): Promise<Event> {
+    const event: Event = {
+      id: randomUUID(),
+      message,
+      progress: "",
+      createdAt: new Date(),
+      status: "pending",
+    };
+
+    this.db.run(
+      `INSERT INTO events (id, message, progress, createdAt, status) VALUES (?, ?, ?, ?, ?)`,
+      [
+        event.id,
+        event.message,
+        event.progress,
+        event.createdAt.toISOString(),
+        event.status,
+      ],
+    );
+
+    this.logger.debug(`Added event ${event.id}: ${message}`);
+
+    return event;
+  }
+
+  /**
+   * Gets all pending events from the queue
+   */
   async getPending(): Promise<Event[]> {
-    throw new Error("Not implemented - Issue #2");
+    const stmt = this.db.query<EventRow, [string]>(
+      `SELECT * FROM events WHERE status = ? ORDER BY createdAt ASC`,
+    );
+    const rows = stmt.all("pending");
+
+    return rows.map((row) => this.rowToEvent(row));
   }
 
-  async getById(_id: string): Promise<Event | null> {
-    throw new Error("Not implemented - Issue #2");
+  /**
+   * Gets a single event by ID
+   */
+  async getById(id: string): Promise<Event | null> {
+    const stmt = this.db.query<EventRow, [string]>(
+      `SELECT * FROM events WHERE id = ?`,
+    );
+    const row = stmt.get(id);
+
+    return row ? this.rowToEvent(row) : null;
   }
 
-  async updateProgress(_id: string, _progress: string): Promise<void> {
-    throw new Error("Not implemented - Issue #2");
+  /**
+   * Updates the progress field of an event
+   */
+  async updateProgress(id: string, progress: string): Promise<void> {
+    const result = this.db.run(`UPDATE events SET progress = ? WHERE id = ?`, [
+      progress,
+      id,
+    ]);
+
+    if (result.changes === 0) {
+      throw new Error(`Event not found: ${id}`);
+    }
+
+    this.logger.debug(`Updated progress for event ${id}: ${progress}`);
   }
 
-  async markComplete(_id: string): Promise<void> {
-    throw new Error("Not implemented - Issue #2");
+  /**
+   * Marks an event as completed
+   */
+  async markComplete(id: string): Promise<void> {
+    const result = this.db.run(
+      `UPDATE events SET status = 'completed' WHERE id = ?`,
+      [id],
+    );
+
+    if (result.changes === 0) {
+      throw new Error(`Event not found: ${id}`);
+    }
+
+    this.logger.info(`Marked event ${id} as completed`);
   }
 
-  async purgeCompleted(_olderThan: Date): Promise<number> {
-    throw new Error("Not implemented - Issue #2");
+  /**
+   * Purges completed events older than the given date
+   * @returns Number of events purged
+   */
+  async purgeCompleted(olderThan: Date): Promise<number> {
+    const result = this.db.run(
+      `DELETE FROM events WHERE status = 'completed' AND createdAt < ?`,
+      [olderThan.toISOString()],
+    );
+
+    this.logger.info(
+      `Purged ${result.changes} completed events older than ${olderThan.toISOString()}`,
+    );
+
+    return result.changes;
+  }
+
+  /**
+   * Closes the database connection
+   */
+  close(): void {
+    this.db.close();
+    this.logger.debug("Event queue database connection closed");
+  }
+
+  /**
+   * Converts a database row to an Event object
+   */
+  private rowToEvent(row: EventRow): Event {
+    return {
+      id: row.id,
+      message: row.message,
+      progress: row.progress,
+      createdAt: new Date(row.createdAt),
+      status: row.status as "pending" | "completed",
+    };
   }
 }


### PR DESCRIPTION
Closes #2

## Summary

Implements the SQLite-based event queue for OtterAssist as specified in Issue #2 and the architecture plan.

## Changes

- **SQLiteEventQueue class** - Full implementation of the  interface
- **Factory method** -  initializes database and creates schema
- **Persistence** - Uses Bun's built-in SQLite, stored at `~/.otterassist/events.db`

## API

| Method | Description |
|--------|-------------|
| `add(message)` | Creates new event with auto-generated UUID |
| `getPending()` | Returns all pending events, ordered by creation time |
| `getById(id)` | Fetches single event by ID |
| `updateProgress(id, progress)` | Updates progress notes on an event |
| `markComplete(id)` | Marks event as completed |
| `purgeCompleted(olderThan)` | Cleans up old completed events |
| `close()` | Closes the database connection |

## Database Schema

- Events table with CHECK constraint on status (`pending` | `completed`)
- Index on `status` column for fast pending queries

## Testing

All methods tested and working:
- ✅ Add events
- ✅ Get pending events
- ✅ Get by ID
- ✅ Update progress
- ✅ Mark complete
- ✅ Purge completed
- ✅ Error handling for missing events