### PR TITLE
Add built-in /wrap_up command for event processing

### DIFF
--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -2,9 +2,12 @@
  * Tests for Agent Runner
  */
 
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Event, EventQueue, Logger } from "../types/index.ts";
-import { AgentRunner } from "./runner.ts";
+import { AgentRunner, ensureWrapUpPrompt, WRAP_UP_PROMPT } from "./runner.ts";
 
 // Mock logger
 const createMockLogger = (): Logger => ({
@@ -29,6 +32,100 @@ const createMockEventQueue = (): EventQueue => ({
   markComplete: mock(async () => {}),
   purgeCompleted: mock(async () => 0),
   close: mock(() => {}),
+});
+
+describe("ensureWrapUpPrompt", () => {
+  let tempDir: string;
+  let mockLogger: Logger;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `otterassist-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+    mockLogger = createMockLogger();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should create prompts directory if it doesn't exist", async () => {
+    const agentDir = join(tempDir, "agent");
+    // Don't create prompts dir beforehand
+    await ensureWrapUpPrompt(agentDir, mockLogger);
+
+    const wrapUpPath = join(agentDir, "prompts", "wrap_up.md");
+    const file = Bun.file(wrapUpPath);
+    const exists = await file.exists();
+    expect(exists).toBe(true); // File exists implies directory was created
+  });
+
+  it("should write correct content to wrap_up.md", async () => {
+    const agentDir = join(tempDir, "agent");
+    await ensureWrapUpPrompt(agentDir, mockLogger);
+
+    const wrapUpPath = join(agentDir, "prompts", "wrap_up.md");
+    const file = Bun.file(wrapUpPath);
+    const content = await file.text();
+
+    expect(content).toBe(WRAP_UP_PROMPT);
+    expect(content).toContain("Wrap up the current session");
+    expect(content).toContain(
+      "Marking all events that have been completely handled",
+    );
+  });
+
+  it("should not overwrite existing wrap_up.md", async () => {
+    const agentDir = join(tempDir, "agent");
+    const promptsDir = join(agentDir, "prompts");
+    const wrapUpPath = join(promptsDir, "wrap_up.md");
+
+    // Create existing file with custom content
+    await mkdir(promptsDir, { recursive: true });
+    const customContent = "---\ndescription: Custom\n---\nCustom content";
+    await Bun.write(wrapUpPath, customContent);
+
+    await ensureWrapUpPrompt(agentDir, mockLogger);
+
+    const file = Bun.file(wrapUpPath);
+    const content = await file.text();
+    expect(content).toBe(customContent);
+  });
+
+  it("should work without a logger", async () => {
+    const agentDir = join(tempDir, "agent");
+    await ensureWrapUpPrompt(agentDir);
+
+    const wrapUpPath = join(agentDir, "prompts", "wrap_up.md");
+    const file = Bun.file(wrapUpPath);
+    const exists = await file.exists();
+    expect(exists).toBe(true);
+  });
+});
+
+describe("WRAP_UP_PROMPT", () => {
+  it("should have correct description in frontmatter", () => {
+    expect(WRAP_UP_PROMPT).toContain(
+      "description: Wrap up the current session and update event progress",
+    );
+  });
+
+  it("should instruct to mark complete events as complete", () => {
+    expect(WRAP_UP_PROMPT).toContain(
+      "Marking all events that have been completely handled as complete",
+    );
+  });
+
+  it("should instruct to update progress holistically", () => {
+    expect(WRAP_UP_PROMPT).toContain(
+      "If there is already progress update it with a full holistic view",
+    );
+  });
+
+  it("should instruct to leave untouched events alone", () => {
+    expect(WRAP_UP_PROMPT).toContain(
+      "Events that you were unable to make progress on just leave untouched",
+    );
+  });
 });
 
 describe("AgentRunner", () => {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -4,6 +4,7 @@
  * @see Issue #23 (pi extension integration)
  */
 
+import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
@@ -25,6 +26,57 @@ import {
 
 /** Default agent directory for OtterAssist */
 export const DEFAULT_AGENT_DIR = join(homedir(), ".otterassist", "agent");
+
+/** Wrap up prompt content for the /wrap_up command */
+export const WRAP_UP_PROMPT = `---
+description: Wrap up the current session and update event progress
+---
+You must wrap up now. Please stop handling the event(s) immediately. Complete the wrap up process by:
+
+1. Marking all events that have been completely handled as complete.
+2. Updating the progress on all events that have been partially worked on. If there is already progress update it with a full holistic view that includes both the past progress and the current progress, do not just overwrite it with what you have done in this session.
+3. Events that you were unable to make progress on just leave untouched.
+
+Once you have done this you can stop.
+`;
+
+/** Filename for the wrap_up prompt template */
+const WRAP_UP_FILENAME = "wrap_up.md";
+
+/**
+ * Ensures the wrap_up prompt template exists in the agent directory.
+ * Creates the prompts directory and wrap_up.md file if they don't exist.
+ *
+ * @param agentDir - The agent directory path (e.g., ~/.otterassist/agent)
+ * @param logger - Optional logger for debug output
+ */
+export async function ensureWrapUpPrompt(
+  agentDir: string,
+  logger?: Logger,
+): Promise<void> {
+  const promptsDir = join(agentDir, "prompts");
+  const wrapUpPath = join(promptsDir, WRAP_UP_FILENAME);
+
+  try {
+    // Create prompts directory if it doesn't exist
+    await mkdir(promptsDir, { recursive: true });
+
+    // Check if wrap_up.md already exists
+    const file = Bun.file(wrapUpPath);
+    const exists = await file.exists();
+
+    if (!exists) {
+      // Write the wrap_up prompt template
+      await Bun.write(wrapUpPath, WRAP_UP_PROMPT);
+      logger?.debug(`Created wrap_up prompt template at ${wrapUpPath}`);
+    }
+  } catch (error) {
+    // Log warning but don't fail - the agent can still run without the prompt
+    logger?.warn(
+      `Failed to ensure wrap_up prompt: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}
 
 /** System prompt for the OtterAssist agent */
 const OTTERASSIST_SYSTEM_PROMPT = `You are OtterAssist, an AI agent that processes events from a queue. You help users by reading files, executing commands, editing code, and writing new files.
@@ -127,6 +179,9 @@ export class AgentRunner {
    * @returns Result of the agent run
    */
   async run(events: Event[]): Promise<AgentRunResult> {
+    // Ensure wrap_up prompt template exists
+    await ensureWrapUpPrompt(this.agentDir, this.logger);
+
     if (events.length === 0) {
       this.logger.debug("No events to process");
       return { eventsProcessed: [], success: true };

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ export {
   type AgentRunnerOptions,
   type AgentRunResult,
   DEFAULT_AGENT_DIR,
+  ensureWrapUpPrompt,
   type Runner,
+  WRAP_UP_PROMPT,
 } from "./core/runner.ts";
 export { Scheduler } from "./core/scheduler.ts";
 


### PR DESCRIPTION
## Summary

- Adds a built-in `/wrap_up` command that instructs the agent to stop processing events and finalize their state
- Implements the command as a prompt template that is auto-discovered by pi's DefaultResourceLoader

## Changes

- Added `WRAP_UP_PROMPT` constant containing the wrap up instructions
- Added `ensureWrapUpPrompt()` function to create `~/.otterassist/agent/prompts/wrap_up.md` if it doesn't exist
- Called `ensureWrapUpPrompt()` in `AgentRunner.run()` before processing events
- Exported `ensureWrapUpPrompt` and `WRAP_UP_PROMPT` from `index.ts`
- Added tests for `ensureWrapUpPrompt()` and `WRAP_UP_PROMPT`

## How it works

1. When `AgentRunner.run()` is called, it first calls `ensureWrapUpPrompt()`
2. This creates `~/.otterassist/agent/prompts/wrap_up.md` if it doesn't exist
3. pi's `DefaultResourceLoader` auto-discovers the prompt template
4. `/wrap_up` becomes available as a command in the agent

## The wrap_up prompt

The prompt instructs the agent to:
1. Mark all completely handled events as complete
2. Update progress on partially worked events (holistically, not overwriting)
3. Leave untouched any events that couldn't be progressed

Closes #33