### PR TITLE
Add built-in context threshold extension for auto wrap-up

### DIFF
--- a/src/builtins/extensions.test.ts
+++ b/src/builtins/extensions.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for built-in extensions
+ * @see Issue #37
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  BUILTIN_EXTENSIONS,
+  getOptionalExtensions,
+  getRequiredExtensions,
+  wrapUpState,
+} from "../builtins/index.ts";
+import { getBuiltinExtensions } from "../extensions/loader.ts";
+
+describe("Built-in Extensions", () => {
+  describe("BUILTIN_EXTENSIONS", () => {
+    test("should contain wrap-up-manager and context-threshold", () => {
+      const names = BUILTIN_EXTENSIONS.map((ext) => ext.name);
+      expect(names).toContain("wrap-up-manager");
+      expect(names).toContain("context-threshold");
+    });
+
+    test("all extensions should have required properties", () => {
+      for (const ext of BUILTIN_EXTENSIONS) {
+        expect(ext.name).toBeDefined();
+        expect(ext.description).toBeDefined();
+        expect(typeof ext.name).toBe("string");
+        expect(typeof ext.description).toBe("string");
+      }
+    });
+  });
+
+  describe("getRequiredExtensions", () => {
+    test("should return only extensions with allowDisable: false", () => {
+      const required = getRequiredExtensions();
+      const names = required.map((ext) => ext.name);
+
+      expect(names).toContain("wrap-up-manager");
+      expect(names).not.toContain("context-threshold");
+    });
+
+    test("all required extensions should have allowDisable: false", () => {
+      const required = getRequiredExtensions();
+      for (const ext of required) {
+        expect(ext.allowDisable).toBe(false);
+      }
+    });
+  });
+
+  describe("getOptionalExtensions", () => {
+    test("should return only extensions with allowDisable: true", () => {
+      const optional = getOptionalExtensions();
+      const names = optional.map((ext) => ext.name);
+
+      expect(names).toContain("context-threshold");
+      expect(names).not.toContain("wrap-up-manager");
+    });
+  });
+
+  describe("getBuiltinExtensions (loader)", () => {
+    test("should return LoadedExtension objects with correct properties", () => {
+      const loaded = getBuiltinExtensions();
+
+      expect(loaded.length).toBe(BUILTIN_EXTENSIONS.length);
+
+      for (const ext of loaded) {
+        expect(ext.isBuiltin).toBe(true);
+        expect(typeof ext.allowDisable).toBe("boolean");
+        expect(ext.name).toBeDefined();
+        expect(ext.description).toBeDefined();
+      }
+    });
+
+    test("wrap-up-manager should have allowDisable: false", () => {
+      const loaded = getBuiltinExtensions();
+      const wrapUpManager = loaded.find(
+        (ext) => ext.name === "wrap-up-manager",
+      );
+
+      expect(wrapUpManager).toBeDefined();
+      expect(wrapUpManager?.allowDisable).toBe(false);
+    });
+
+    test("context-threshold should have allowDisable: true", () => {
+      const loaded = getBuiltinExtensions();
+      const contextThreshold = loaded.find(
+        (ext) => ext.name === "context-threshold",
+      );
+
+      expect(contextThreshold).toBeDefined();
+      expect(contextThreshold?.allowDisable).toBe(true);
+    });
+  });
+
+  describe("wrapUpState", () => {
+    test("should have queued property initialized to false", () => {
+      expect(wrapUpState.queued).toBe(false);
+    });
+
+    test("should allow setting queued to true", () => {
+      const originalValue = wrapUpState.queued;
+      wrapUpState.queued = true;
+      expect(wrapUpState.queued).toBe(true);
+      wrapUpState.queued = originalValue; // Reset
+    });
+  });
+});

--- a/src/builtins/extensions/context-threshold.ts
+++ b/src/builtins/extensions/context-threshold.ts
@@ -1,0 +1,69 @@
+/**
+ * Context Threshold - Built-in extension that auto-triggers wrap-up
+ *
+ * Monitors context usage after each turn and automatically queues
+ * the /wrap_up command when context exceeds the threshold (80%).
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { OtterAssistExtension } from "../../types/index.ts";
+import { wrapUpState } from "./wrap-up-manager.ts";
+
+/**
+ * Default context threshold (80% of context window).
+ * When context usage reaches this level, wrap-up is triggered.
+ */
+const DEFAULT_THRESHOLD = 0.8;
+
+/**
+ * The context threshold pi extension function.
+ * Monitors turn_end events and triggers wrap-up when threshold exceeded.
+ */
+const piExtension = (pi: ExtensionAPI): void => {
+  pi.on("turn_end", (_event, ctx) => {
+    // Skip if wrap-up already queued by another extension
+    if (wrapUpState.queued) {
+      return;
+    }
+
+    // Get current context usage
+    const usage = ctx.getContextUsage();
+    if (!usage || usage.percent === null) {
+      return;
+    }
+
+    const thresholdPercent = DEFAULT_THRESHOLD * 100;
+
+    // Check if threshold exceeded
+    if (usage.percent >= thresholdPercent) {
+      // Set the flag to prevent duplicate wrap-ups
+      wrapUpState.queued = true;
+
+      // Notify user if UI is available
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `Context at ${usage.percent.toFixed(1)}% (threshold: ${thresholdPercent}%). Queuing /wrap_up...`,
+          "warning",
+        );
+      }
+
+      // Queue the wrap_up command as a follow-up message
+      pi.sendUserMessage("/wrap_up", { deliverAs: "followUp" });
+    }
+  });
+};
+
+/**
+ * Context Threshold built-in extension.
+ *
+ * This extension can be enabled/disabled via the setup wizard.
+ * When enabled, it monitors context usage and triggers automatic wrap-up.
+ */
+export default {
+  name: "context-threshold",
+  description: "Auto-trigger /wrap_up when context exceeds 80%",
+  version: "1.0.0",
+  /** This extension can be disabled by the user */
+  allowDisable: true,
+  piExtension,
+} satisfies OtterAssistExtension;

--- a/src/builtins/extensions/wrap-up-manager.ts
+++ b/src/builtins/extensions/wrap-up-manager.ts
@@ -1,0 +1,46 @@
+/**
+ * Wrap-up Manager - Built-in extension that coordinates wrap-up behavior
+ *
+ * This extension manages the shared wrap-up state that other extensions
+ * can use to coordinate automatic wrap-up triggers. It cannot be disabled.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { OtterAssistExtension } from "../../types/index.ts";
+
+/**
+ * Shared state for wrap-up coordination across extensions.
+ *
+ * Other extensions can import this to check or set the wrap-up queued state:
+ * - Check before triggering another wrap-up to avoid duplicates
+ * - Set to true when queuing a wrap-up command
+ */
+export const wrapUpState = {
+  /** Whether a wrap-up command has already been queued for this session */
+  queued: false,
+};
+
+/**
+ * The wrap-up manager pi extension function.
+ * Resets the wrap-up state on each session start.
+ */
+const piExtension = (pi: ExtensionAPI): void => {
+  pi.on("session_start", () => {
+    wrapUpState.queued = false;
+  });
+};
+
+/**
+ * Wrap-up Manager built-in extension.
+ *
+ * This extension is always enabled and provides the coordination flag
+ * for other wrap-up related extensions.
+ */
+export default {
+  name: "wrap-up-manager",
+  description: "Coordinates wrap-up behavior across extensions",
+  version: "1.0.0",
+  /** This extension cannot be disabled */
+  allowDisable: false,
+  piExtension,
+} satisfies OtterAssistExtension;

--- a/src/builtins/index.ts
+++ b/src/builtins/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Built-in extensions module
+ *
+ * Exports all built-in extensions that ship with OtterAssist.
+ * These extensions are always available and can be enabled/disabled
+ * via the setup wizard (except for required extensions).
+ */
+
+import type { OtterAssistExtension } from "../types/index.ts";
+import contextThreshold from "./extensions/context-threshold.ts";
+import wrapUpManager from "./extensions/wrap-up-manager.ts";
+
+// Re-export wrap-up state for other extensions to use
+export { wrapUpState } from "./extensions/wrap-up-manager.ts";
+
+/**
+ * All built-in extensions that ship with OtterAssist.
+ *
+ * These extensions are automatically discovered and loaded by the
+ * ExtensionManager. They appear in the setup wizard alongside
+ * user-installed extensions.
+ */
+export const BUILTIN_EXTENSIONS: OtterAssistExtension[] = [
+  wrapUpManager,
+  contextThreshold,
+];
+
+/**
+ * Get built-in extensions that cannot be disabled.
+ */
+export function getRequiredExtensions(): OtterAssistExtension[] {
+  return BUILTIN_EXTENSIONS.filter(
+    (ext) => (ext as { allowDisable?: boolean }).allowDisable === false,
+  );
+}
+
+/**
+ * Get built-in extensions that can be disabled by the user.
+ */
+export function getOptionalExtensions(): OtterAssistExtension[] {
+  return BUILTIN_EXTENSIONS.filter(
+    (ext) => (ext as { allowDisable?: boolean }).allowDisable !== false,
+  );
+}
+
+// Re-export individual extensions for direct imports
+export { contextThreshold, wrapUpManager };

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -31,6 +31,7 @@ export {
 export {
   discoverExtensions,
   GLOBAL_EXTENSIONS_DIR,
+  getBuiltinExtensions,
   LOCAL_EXTENSIONS_DIR,
   type LoadedExtension,
   loadExtension,

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -2,12 +2,14 @@
  * Extension loader - discovers and loads OtterAssist extensions
  * @see Issue #4 (original event source extensions)
  * @see Issue #23 (enhanced extension system with pi integration)
+ * @see Issue #37 (built-in extensions for wrap-up coordination)
  */
 
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { BUILTIN_EXTENSIONS } from "../builtins/index.ts";
 import type {
   EventSourceExtension,
   OtterAssistExtension,
@@ -37,6 +39,10 @@ export interface LoadedExtension {
   version?: string;
   configSchema?: Record<string, unknown>;
   defaultConfig?: unknown;
+  /** Whether this extension can be disabled by the user */
+  allowDisable: boolean;
+  /** Whether this is a built-in extension (ships with OtterAssist) */
+  isBuiltin: boolean;
   /** Event source definition (may be undefined for pi-only extensions) */
   events?: {
     poll(): Promise<string[]>;
@@ -184,6 +190,45 @@ function isValidNewExtension(obj: unknown): obj is OtterAssistExtension {
 }
 
 /**
+ * Converts an OtterAssistExtension to LoadedExtension format.
+ */
+function extensionToLoaded(
+  extension: OtterAssistExtension,
+  isBuiltin: boolean,
+): LoadedExtension {
+  return {
+    name: extension.name,
+    description: extension.description,
+    version: extension.version,
+    configSchema: extension.configSchema,
+    defaultConfig: extension.defaultConfig,
+    allowDisable: extension.allowDisable !== false,
+    isBuiltin,
+    events: extension.events
+      ? {
+          poll: extension.events.poll.bind(extension.events),
+          initialize: extension.events.initialize?.bind(extension.events),
+          shutdown: extension.events.shutdown?.bind(extension.events),
+        }
+      : undefined,
+    piExtension: extension.piExtension as ExtensionFactory | undefined,
+    isLegacy: false,
+  };
+}
+
+/**
+ * Gets all built-in extensions as LoadedExtension objects.
+ *
+ * Built-in extensions ship with OtterAssist and are always available.
+ * They can be enabled/disabled via config (except those with allowDisable: false).
+ *
+ * @returns Array of built-in extensions in LoadedExtension format
+ */
+export function getBuiltinExtensions(): LoadedExtension[] {
+  return BUILTIN_EXTENSIONS.map((ext) => extensionToLoaded(ext, true));
+}
+
+/**
  * Loads an extension module and normalizes it to LoadedExtension format.
  *
  * Supports both formats:
@@ -205,22 +250,7 @@ export async function loadExtension(
 
     // Try new format first
     if (isValidNewExtension(extension)) {
-      return {
-        name: extension.name,
-        description: extension.description,
-        version: extension.version,
-        configSchema: extension.configSchema,
-        defaultConfig: extension.defaultConfig,
-        events: extension.events
-          ? {
-              poll: extension.events.poll.bind(extension.events),
-              initialize: extension.events.initialize?.bind(extension.events),
-              shutdown: extension.events.shutdown?.bind(extension.events),
-            }
-          : undefined,
-        piExtension: extension.piExtension,
-        isLegacy: false,
-      };
+      return extensionToLoaded(extension, false);
     }
 
     // Fall back to legacy format
@@ -230,6 +260,8 @@ export async function loadExtension(
         description: extension.description,
         configSchema: extension.configSchema,
         defaultConfig: extension.defaultConfig,
+        allowDisable: true,
+        isBuiltin: false,
         events: {
           poll: extension.poll.bind(extension),
           initialize: extension.initialize?.bind(extension),

--- a/src/extensions/manager.ts
+++ b/src/extensions/manager.ts
@@ -2,6 +2,7 @@
  * Extension manager - handles lifecycle of OtterAssist extensions
  * @see Issue #4 (original event source extensions)
  * @see Issue #23 (enhanced extension system with pi integration)
+ * @see Issue #37 (built-in extensions for wrap-up coordination)
  */
 
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
@@ -9,6 +10,7 @@ import { CONFIG_DIR } from "../config/loader.ts";
 import type { Config, Logger, OAExtensionContext } from "../types/index.ts";
 import {
   discoverExtensions,
+  getBuiltinExtensions,
   type LoadedExtension,
   loadExtension,
 } from "./loader.ts";
@@ -18,6 +20,7 @@ import {
  *
  * Handles:
  * - Discovery and loading of extensions from disk
+ * - Loading of built-in extensions (always available)
  * - Lifecycle management (initialize, poll, shutdown)
  * - Separation of event sources and pi extensions
  */
@@ -39,21 +42,81 @@ export class ExtensionManager {
   /**
    * Discovers, loads, filters, and initializes all extensions.
    *
+   * Loading order:
+   * 1. Built-in extensions with allowDisable: false (always loaded)
+   * 2. Built-in extensions with allowDisable: true (check config)
+   * 3. User-installed extensions from filesystem (check config)
+   *
    * For each enabled extension:
    * 1. Loads the extension module
    * 2. Initializes the event source (if present)
    * 3. Collects pi extension function (if present)
    */
   async loadAll(): Promise<void> {
-    this.logger.info("Discovering extensions...");
+    this.logger.info("Loading extensions...");
 
+    // Load built-in extensions first
+    await this.loadBuiltinExtensions();
+
+    // Then load user-installed extensions from filesystem
+    await this.loadUserExtensions();
+
+    this.logger.info(
+      `Loaded ${this.extensions.size} extension(s), ${this.piExtensions.length} with pi integration`,
+    );
+  }
+
+  /**
+   * Loads built-in extensions that ship with OtterAssist.
+   */
+  private async loadBuiltinExtensions(): Promise<void> {
+    const builtins = getBuiltinExtensions();
+    this.logger.debug(`Found ${builtins.length} built-in extension(s)`);
+
+    for (const extension of builtins) {
+      const extensionName = extension.name;
+
+      // Required extensions are always loaded
+      if (!extension.allowDisable) {
+        this.logger.debug(
+          `Loading required built-in extension: ${extensionName}`,
+        );
+        await this.registerExtension(extension, undefined);
+        continue;
+      }
+
+      // Optional built-ins check config like user extensions
+      const extensionConfig = this.config.extensions[extensionName];
+      if (!extensionConfig?.enabled) {
+        this.logger.debug(
+          `Built-in extension "${extensionName}" is disabled, skipping`,
+        );
+        continue;
+      }
+
+      await this.registerExtension(extension, extensionConfig.config);
+    }
+  }
+
+  /**
+   * Loads user-installed extensions from the filesystem.
+   */
+  private async loadUserExtensions(): Promise<void> {
     const extensionPaths = await discoverExtensions();
-    this.logger.info(`Found ${extensionPaths.length} extension(s)`);
+    this.logger.debug(`Found ${extensionPaths.length} user extension(s)`);
 
     for (const path of extensionPaths) {
       try {
         const extension = await loadExtension(path);
         const extensionName = extension.name;
+
+        // Skip if already loaded (built-in takes precedence)
+        if (this.extensions.has(extensionName)) {
+          this.logger.debug(
+            `Extension "${extensionName}" already loaded (built-in), skipping user version`,
+          );
+          continue;
+        }
 
         // Check if extension is enabled in config
         const extensionConfig = this.config.extensions[extensionName];
@@ -72,44 +135,53 @@ export class ExtensionManager {
           );
         }
 
-        // Initialize the event source if present
-        if (extension.events?.initialize) {
-          const context: OAExtensionContext = {
-            configDir: CONFIG_DIR,
-            logger: this.createExtensionLogger(extensionName),
-          };
-
-          const config = extensionConfig.config ?? extension.defaultConfig;
-          await extension.events.initialize(config, context);
-        }
-
-        // Store the extension
-        this.extensions.set(extensionName, extension);
-
-        // Collect pi extension function if present
-        if (extension.piExtension) {
-          this.piExtensions.push(extension.piExtension);
-          this.logger.debug(
-            `Extension "${extensionName}" registered pi extension`,
-          );
-        }
-
-        // Log loaded extension
-        const hasEvents = extension.events ? "events" : "";
-        const hasPi = extension.piExtension ? "pi" : "";
-        const capabilities = [hasEvents, hasPi].filter(Boolean).join("+");
-        const version = extension.version ? ` v${extension.version}` : "";
-
-        this.logger.info(
-          `Loaded extension: ${extensionName}${version} - ${extension.description} [${capabilities || "empty"}]`,
+        await this.registerExtension(
+          extension,
+          extensionConfig.config ?? extension.defaultConfig,
         );
       } catch (error) {
         this.logger.error(`Failed to load extension from ${path}:`, error);
       }
     }
+  }
+
+  /**
+   * Registers an extension (initializes event source, collects pi extension).
+   */
+  private async registerExtension(
+    extension: LoadedExtension,
+    config: unknown,
+  ): Promise<void> {
+    const extensionName = extension.name;
+
+    // Initialize the event source if present
+    if (extension.events?.initialize) {
+      const context: OAExtensionContext = {
+        configDir: CONFIG_DIR,
+        logger: this.createExtensionLogger(extensionName),
+      };
+
+      await extension.events.initialize(config, context);
+    }
+
+    // Store the extension
+    this.extensions.set(extensionName, extension);
+
+    // Collect pi extension function if present
+    if (extension.piExtension) {
+      this.piExtensions.push(extension.piExtension);
+      this.logger.debug(`Extension "${extensionName}" registered pi extension`);
+    }
+
+    // Log loaded extension
+    const hasEvents = extension.events ? "events" : "";
+    const hasPi = extension.piExtension ? "pi" : "";
+    const capabilities = [hasEvents, hasPi].filter(Boolean).join("+");
+    const version = extension.version ? ` v${extension.version}` : "";
+    const builtin = extension.isBuiltin ? " [built-in]" : "";
 
     this.logger.info(
-      `Loaded ${this.extensions.size} extension(s), ${this.piExtensions.length} with pi integration`,
+      `Loaded extension: ${extensionName}${version}${builtin} - ${extension.description} [${capabilities || "empty"}]`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,15 @@
  * by an AI agent on a scheduled basis.
  */
 
+// Re-export builtins
+export {
+  BUILTIN_EXTENSIONS,
+  contextThreshold,
+  getOptionalExtensions,
+  getRequiredExtensions,
+  wrapUpManager,
+  wrapUpState,
+} from "./builtins/index.ts";
 // Re-export CLI
 export { parseArgs, runCli } from "./cli/index.ts";
 export { loadConfig, saveConfig } from "./config/loader.ts";
@@ -33,7 +42,6 @@ export {
   WRAP_UP_PROMPT,
 } from "./core/runner.ts";
 export { Scheduler } from "./core/scheduler.ts";
-
 // Re-export event management tools
 export {
   createCompleteEventTool,

--- a/src/setup/screens/extensions.ts
+++ b/src/setup/screens/extensions.ts
@@ -37,13 +37,28 @@ class ExtensionsScreen extends Container implements ScreenComponent {
     this.state = state;
     this.extensions = extensions;
 
-    // Build settings items
-    const items: SettingItem[] = extensions.map((ext) => ({
-      id: ext.name,
-      label: ext.name,
-      currentValue: state.extensions.get(ext.name)?.enabled ? "on" : "off",
-      values: ["on", "off"] as const,
-    }));
+    // Build settings items - non-disableable extensions show as locked
+    const items: SettingItem[] = extensions.map((ext) => {
+      const isRequired = !ext.allowDisable;
+
+      if (isRequired) {
+        // Required extensions show as "required" and cannot be toggled
+        return {
+          id: ext.name,
+          label: `${ext.name} 🔒`,
+          currentValue: "required",
+          values: ["required"] as const,
+        };
+      }
+
+      // Optional extensions can be toggled
+      return {
+        id: ext.name,
+        label: ext.isBuiltin ? `${ext.name} (built-in)` : ext.name,
+        currentValue: state.extensions.get(ext.name)?.enabled ? "on" : "off",
+        values: ["on", "off"] as const,
+      };
+    });
 
     // Create settings list with theme
     this.settingsList = new SettingsList(
@@ -52,15 +67,20 @@ class ExtensionsScreen extends Container implements ScreenComponent {
       {
         label: (s: string, selected: boolean) =>
           selected ? theme.accent(theme.bold(s)) : theme.text(s),
-        value: (s: string, selected: boolean) =>
-          selected ? theme.accent(s) : theme.muted(s),
+        value: (s: string, selected: boolean) => {
+          if (s === "required") {
+            return theme.muted("required");
+          }
+          return selected ? theme.accent(s) : theme.muted(s);
+        },
         description: (s: string) => theme.dim(s),
         cursor: ">",
         hint: (s: string) => theme.dim(s),
       },
       (id: string, newValue: string) => {
         const ext = this.state.extensions.get(id);
-        if (ext) {
+        // Only allow toggling for optional extensions
+        if (ext?.info.allowDisable) {
           ext.enabled = newValue === "on";
         }
       },
@@ -102,6 +122,13 @@ class ExtensionsScreen extends Container implements ScreenComponent {
       this.addChild(
         new Text(
           this.theme.dim(`     Found ${this.extensions.length} extension(s)`),
+          0,
+          0,
+        ),
+      );
+      this.addChild(
+        new Text(
+          this.theme.dim("     🔒 = required, cannot be disabled"),
           0,
           0,
         ),

--- a/src/setup/wizard.test.ts
+++ b/src/setup/wizard.test.ts
@@ -12,11 +12,15 @@ const mockExtensions: ExtensionInfo[] = [
     name: "test-extension",
     description: "A test extension",
     path: "/tmp/test-extension.ts",
+    allowDisable: true,
+    isBuiltin: false,
   },
   {
     name: "another-extension",
     description: "Another test extension",
     path: "/tmp/another-extension.ts",
+    allowDisable: true,
+    isBuiltin: false,
   },
 ];
 

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -12,7 +12,11 @@ import {
   loadConfig,
   saveConfig,
 } from "../config/loader.ts";
-import { discoverExtensions, loadExtension } from "../extensions/index.ts";
+import {
+  discoverExtensions,
+  getBuiltinExtensions,
+  loadExtension,
+} from "../extensions/index.ts";
 import type { Config } from "../types/index.ts";
 import { createExtensionsScreen } from "./screens/extensions.ts";
 import { createPollIntervalScreen } from "./screens/poll-interval.ts";
@@ -26,6 +30,10 @@ export interface ExtensionInfo {
   name: string;
   description: string;
   path: string;
+  /** Whether this extension can be disabled by the user */
+  allowDisable: boolean;
+  /** Whether this is a built-in extension */
+  isBuiltin: boolean;
 }
 
 /**
@@ -247,19 +255,42 @@ export async function isFirstRun(configPath?: string): Promise<boolean> {
 
 /**
  * Discover and load extension info for the wizard
+ * Includes both built-in and user-installed extensions.
  * @returns Array of extension info objects
  */
 export async function discoverExtensionInfo(): Promise<ExtensionInfo[]> {
-  const extensionPaths = await discoverExtensions();
   const infos: ExtensionInfo[] = [];
+
+  // Add built-in extensions first
+  const builtins = getBuiltinExtensions();
+  for (const ext of builtins) {
+    infos.push({
+      name: ext.name,
+      description: ext.description,
+      path: "(built-in)",
+      allowDisable: ext.allowDisable,
+      isBuiltin: true,
+    });
+  }
+
+  // Then add user-installed extensions from filesystem
+  const extensionPaths = await discoverExtensions();
 
   for (const path of extensionPaths) {
     try {
       const ext = await loadExtension(path);
+
+      // Skip if already in list (built-in takes precedence)
+      if (infos.some((info) => info.name === ext.name)) {
+        continue;
+      }
+
       infos.push({
         name: ext.name,
         description: ext.description,
         path,
+        allowDisable: ext.allowDisable,
+        isBuiltin: ext.isBuiltin,
       });
     } catch (error) {
       // Skip extensions that fail to load

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -163,19 +163,16 @@ export interface EventSourceDefinition {
  * This is the same function signature used by pi extensions.
  * It receives the ExtensionAPI and can register tools, skills, hooks, commands, etc.
  *
- * Import ExtensionAPI from pi:
+ * For proper type safety, import ExtensionAPI from pi:
  * ```typescript
  * import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
  * ```
  *
- * For proper type safety, import ExtensionFactory directly from pi:
- * ```typescript
- * import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
- * ```
- *
  * @see https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md
  */
-export type PiExtensionFunction = (pi: unknown) => void;
+export type PiExtensionFunction = (
+  pi: import("@mariozechner/pi-coding-agent").ExtensionAPI,
+) => void;
 
 /**
  * OtterAssist Extension - bundles event sources with pi capabilities.
@@ -237,6 +234,21 @@ export interface OtterAssistExtension {
 
   /** Optional default configuration values */
   defaultConfig?: unknown;
+
+  /**
+   * Whether this extension can be disabled by the user.
+   * Built-in extensions can set this to false to enforce always-on behavior.
+   * User-installed extensions default to true (can be disabled).
+   * @default true
+   */
+  allowDisable?: boolean;
+
+  /**
+   * Whether this is a built-in extension (ships with OtterAssist).
+   * This is set automatically for built-in extensions.
+   * @internal
+   */
+  isBuiltin?: boolean;
 
   /**
    * Event source: produces events for the queue.


### PR DESCRIPTION
## Overview

This PR adds two built-in pi extensions that coordinate automatic wrap-up when context usage exceeds a threshold.

Closes #37

## Extensions

### 1. wrap-up-manager (Required, cannot be disabled)
- Manages the shared `wrapUpState.queued` flag
- Resets flag on `session_start`
- Always active - provides coordination for other wrap-up extensions

### 2. context-threshold (Can be enabled/disabled via setup)
- Monitors context usage on `turn_end`
- Checks `wrapUpState.queued` first, does nothing if already true
- If threshold exceeded (80%) and not queued, sets flag and sends `/wrap_up`
- Threshold hardcoded to 0.8 (configuration to be added later)

## Changes

### New Files
- `src/builtins/index.ts` - Exports all built-in extensions
- `src/builtins/extensions/wrap-up-manager.ts` - Wrap-up coordination
- `src/builtins/extensions/context-threshold.ts` - Context monitoring
- `src/builtins/extensions.test.ts` - Tests for built-in extensions

### Modified Files
- `src/types/index.ts` - Added `allowDisable` and `isBuiltin` properties
- `src/extensions/loader.ts` - Added `getBuiltinExtensions()` function
- `src/extensions/manager.ts` - Updated to load built-in extensions
- `src/setup/wizard.ts` - Include built-ins in discovery
- `src/setup/screens/extensions.ts` - Show lock icon for required extensions

## Setup Wizard

Built-in extensions appear in the setup wizard:
- `wrap-up-manager` shows with 🔒 icon (cannot be disabled)
- `context-threshold` can be toggled on/off

## Testing

- All 159 tests pass
- 10 new tests for built-in extensions